### PR TITLE
--home_path (optional) argument added

### DIFF
--- a/dcs_deploy.py
+++ b/dcs_deploy.py
@@ -245,6 +245,9 @@ class DcsDeploy:
         rootfs_help = 'Path to customized root filesystem. Keep in mind that this needs to be a valid tbz2 archive.' 
         subparser.add_argument('--rootfs', help=rootfs_help)
 
+        home_path_help = 'Optional. Specify a custom home path. Defaults to the user home directory.'
+        subparser.add_argument('--home_path', help=home_path_help, default=os.path.expanduser('~'))
+
     def create_parser(self):
         """
         Create an ArgumentParser and all its options
@@ -369,7 +372,7 @@ class DcsDeploy:
             self.config['rootfs_type']
         )
 
-        self.home = os.path.expanduser('~')
+        self.home = self.args.home_path
         self.dsc_deploy_root = os.path.join(self.home, '.dcs_deploy')
         self.download_path = os.path.join(self.dsc_deploy_root, 'download')
         self.flash_path = os.path.join(self.dsc_deploy_root, 'flash', config_relative_path)


### PR DESCRIPTION
A optional argument `--home_path` has been added to allow users to specify path where `.dcs_deploy` fodler will be created. If the optional argument is not used the path will default to `~`.

Example usage:
`python3 dcs_deploy.py flash orin_nx 512 2.0 nvme full --home_path /home/adam/Downloads/`