### PR TITLE
load CAN kernel modules to at boot

### DIFF
--- a/dcs_deploy.py
+++ b/dcs_deploy.py
@@ -617,6 +617,9 @@ class DcsDeploy:
         # Resources destination
         utilities_destination = os.path.join(self.rootfs_extract_dir, 'home', 'dcs_user', 'utilities')
 
+        # Setup kernel modules to load at boot via systemd's modules.d
+        modules_d_destination = os.path.join(self.rootfs_extract_dir, 'etc', 'modules-load.d')
+
         # Create resources directory
         ret += cmd_exec("sudo mkdir -p " + utilities_destination)
         
@@ -649,6 +652,9 @@ class DcsDeploy:
         ret += cmd_exec("sudo cp resources/fan_control/fan_control.service " + service_destination)
         ret += cmd_exec("sudo cp resources/fan_control/fan_control.sh " + bin_destination)
         ret += cmd_exec("sudo chmod +x " + os.path.join(bin_destination, 'fan_control.sh'))
+
+        # CAN kernel modules
+        ret += cmd_exec("sudo cp resources/can_control/can.conf " + modules_d_destination)
 
         # uhubctl
         ret += cmd_exec("sudo cp resources/uhubctl_2.1.0-1_arm64.deb " + uhubctl_destination)

--- a/resources/can_control/can.conf
+++ b/resources/can_control/can.conf
@@ -1,0 +1,3 @@
+can
+can_raw
+mttcan


### PR DESCRIPTION
Hi, here's the PR to load needed CAN kernel modules at boot as described here: #32 . The interface configuration I would say is a client responsibility, so this PR just loads the modules.

I've used [systemd modules.d](https://www.freedesktop.org/software/systemd/man/latest/modules-load.d.html) for this (as its needed on every boot an not only on the first).

Looking for feedback, thanks :)