### PR TITLE
DCS1.2 usb hub start

### DIFF
--- a/local/overlays/hardware_support_layer/resources/services/usb_hub_control/compatible
+++ b/local/overlays/hardware_support_layer/resources/services/usb_hub_control/compatible
@@ -1,8 +1,8 @@
 [
     {
-      "device": ["orin_nx", "orin_nx_super", "orin_nx_super_maxn", "orin_nx_8gb", "orin_nx_8gb_super", "orin_nx_8gb_super_maxn", "orin_nano_8gb", "orin_nano_8gb_super", "orin_nano_4gb", "orin_nano_4gb_super", "xavier_nx"],
+      "device": ["orin_nx", "orin_nx_super", "orin_nx_super_maxn", "orin_nx_8gb", "orin_nx_8gb_super", "orin_nx_8gb_super_maxn", "orin_nano_8gb", "orin_nano_8gb_super", "orin_nano_4gb", "orin_nano_4gb_super"],
       "storage": ["nvme", "emmc"],
-      "board": ["1.2", "2.0"],
+      "board": ["2.0"],
       "board_expansion" : [""],
       "l4t_version": ["62", "512", "512_avt", "51"],
       "rootfs_type": [""]

--- a/local/overlays/hardware_support_layer/resources/services/usb_hub_start/compatible
+++ b/local/overlays/hardware_support_layer/resources/services/usb_hub_start/compatible
@@ -1,0 +1,11 @@
+[
+    {
+      "device": ["orin_nx", "orin_nx_super", "orin_nx_super_maxn", "orin_nx_8gb", "orin_nx_8gb_super", "orin_nx_8gb_super_maxn", "orin_nano_8gb", "orin_nano_8gb_super", "orin_nano_4gb", "orin_nano_4gb_super", "xavier_nx"],
+      "storage": ["nvme", "emmc"],
+      "board": ["1.2"],
+      "board_expansion" : [""],
+      "l4t_version": ["62", "512", "512_avt", "51"],
+      "rootfs_type": [""]
+    }
+  ]
+  

--- a/local/overlays/hardware_support_layer/resources/services/usb_hub_start/usb_hub_start.service
+++ b/local/overlays/hardware_support_layer/resources/services/usb_hub_start/usb_hub_start.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=USB hub start
+After=remote-fs.target
+After=syslog.target
+After=multi-user.target
+Requires=multi-user.target
+
+[Service]
+ExecStartPre=/bin/sleep 5
+ExecStart=/usr/local/bin/usb_hub_start.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/local/overlays/hardware_support_layer/resources/services/usb_hub_start/usb_hub_start.sh
+++ b/local/overlays/hardware_support_layer/resources/services/usb_hub_start/usb_hub_start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Command to initialize the USB hub
+initialize_hub_command="i2cset -y 0 0x2d 0xAA 0x55 0x00 i"
+
+retry_limit=5
+retry_count=0
+
+while [ $retry_count -lt $retry_limit ]; do
+    echo "Attempting to initialize the USB hub (Attempt $((retry_count + 1)))..."
+    $initialize_hub_command
+
+    # Check if the command succeeded
+    if [ $? -eq 0 ]; then
+        echo "USB hub initialized successfully."
+        exit 0
+    else
+        echo "Failed to initialize the USB hub. Retrying..."
+    fi
+
+    retry_count=$((retry_count + 1))
+    sleep 1
+done
+
+echo "Failed to initialize the USB hub after $retry_limit attempts."
+exit 1


### PR DESCRIPTION
added the old script that only turns on hub and doesnt configure it on dcs1.2 systems, due to it having different usb hub