### PR TITLE
Modified usb_cube_disable.service compatibility

### DIFF
--- a/local/overlays/hardware_support_layer/resources/services/usb_cube_disable/compatible
+++ b/local/overlays/hardware_support_layer/resources/services/usb_cube_disable/compatible
@@ -1,6 +1,6 @@
 [
     {
-      "device": ["orin_nx", "orin_nx_super", "orin_nx_super_maxn", "orin_nx_8gb", "orin_nx_8gb_super", "orin_nx_8gb_super_maxn", "orin_nano_8gb", "orin_nano_8gb_super", "orin_nano_4gb", "orin_nano_4gb_super", "xavier_nx"],
+      "device": ["xavier_nx"],
       "storage": ["nvme", "emmc"],
       "board": ["1.2"],
       "board_expansion" : [""],


### PR DESCRIPTION
Removed compatibility with jetson orin gen hw, which are connected to cube via usb.
#56 